### PR TITLE
Adding name attribute to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "freeradius"
 maintainer       "Nick Maloney"
 maintainer_email "ngmaloney@gmail.com"
 license          "All rights reserved"


### PR DESCRIPTION
Berkshelf now requires a `name` attribute in cookbooks' metadata: https://github.com/berkshelf/berkshelf/issues/1197. If the `name` isn't present, you get a `MissingNameAttribute` exception from `ridley`.
