### PR TITLE
Create missing directory and file

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "ngmaloney@gmail.com"
 license          "All rights reserved"
 description      "Installs/Configures freeradius"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.1"
+version          "1.0.2"
 
 %w{ ubuntu centos debian }.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -12,6 +12,21 @@ if node['freeradius']['enable_ldap'] == true
   include_recipe 'freeradius::ldap'
 end
 
+if node['freeradius']['enable_sql']
+  custom_dir = "#{node['freeradius']['dir']}/sql/#{node['freeradius']['db_type']}"
+  directory custom_dir do
+    owner node['freeradius']['user']
+    group node['freeradius']['group']
+    mode 0750
+    notifies :run, "execute[create-dialup-conf]", :immediately
+  end
+  execute "create-dialup-conf" do
+    command "touch #{custom_dir}/dialup.conf"
+    not_if { ::File.exists?("#{custom_dir}/dialup.conf") }
+    action :nothing
+  end
+end
+
 template "#{node['freeradius']['dir']}/sql.conf" do
   source "sql.conf.erb"
   owner node['freeradius']['user']


### PR DESCRIPTION
Create missing directory and file. Kitchen-test doesn't converge for first time. This will create additional directory which is specified in `/etc/raddb/sql.conf`. Without this modification, radius doesn't start, because it searches for `dialup.conf` file. 

```
including configuration file /etc/raddb/sql/postgresql/dialup.conf
Unable to open file "/etc/raddb/sql/postgresql/dialup.conf": No such file or directory
Errors reading /etc/raddb/radiusd.conf
```
