### PR TITLE
Enable SQL support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,17 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_solo
+
+platforms:
+  - name: centos-5.11
+  - name: centos-6.6
+  - name: ubuntu-12.04
+  - name: ubuntu-14.10
+
+suites:
+  - name: default
+    run_list:
+      - recipe[freeradius::default]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,10 +10,10 @@ when 'rhel'
   default['freeradius']['libdir'] = '/usr/lib64/freeradius'
 # Packages to install since centos 5 is freeradius 2 and centos 6 is  just freeradius
   if node.platform_version.to_f < 6
-    default['freeradius']['pkgs'] = %w{ freeradius2 freeradius2-utils }
+    default['freeradius']['pkgs'] = %w{ freeradius2 freeradius2-utils freeradius2-postgresql }
     default['freeradius']['ldap_pkgs'] = %w{ freeradius2-ldap }
   else
-    default['freeradius']['pkgs'] = %w{ freeradius freeradius-utils }
+    default['freeradius']['pkgs'] = %w{ freeradius freeradius-utils freeradius-postgresql }
     default['freeradius']['ldap_pkgs'] = %w{ freeradius-ldap }
   end
 when 'debian'
@@ -24,10 +24,10 @@ when 'debian'
   default['freeradius']['logdir'] = '/var/log/freeradius'
   default['freeradius']['name'] = 'freeradius'
   default['freeradius']['libdir'] = '/usr/lib/freeradius'
-  default['freeradius']['pkgs'] = %w{ freeradius freeradius-common freeradius-utils freeradius-postgresql libdbi-perl libfreeradius2 libnet-daemon-perl libperl5.10 libplrpc-perl libpython2.6 ssl-cert }
+  default['freeradius']['pkgs'] = %w{ freeradius freeradius-common freeradius-utils libfreeradius2 freeradius-postgresql }
   default['freeradius']['ldap_pkgs'] = %w{ freeradius-ldap }
 when 'ubuntu'
-  default['freeradius']['pkgs'] = %w{ freeradius freeradius-common freeradius-utils libfreeradius2 }
+  default['freeradius']['pkgs'] = %w{ freeradius freeradius-common freeradius-utils libfreeradius2 freeradius-postgresql }
   default['freeradius']['ldap_pkgs'] = %w{ freeradius-ldap }
 else
   default['freeradius']['pkgs'] = %w{ }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "ngmaloney@gmail.com"
 license          "All rights reserved"
 description      "Installs/Configures freeradius"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.1"
+version          "1.0.2"
 
 %w{ ubuntu centos debian }.each do |os|
   supports os

--- a/templates/default/default.erb
+++ b/templates/default/default.erb
@@ -156,7 +156,9 @@ authorize {
   #  is meant to mirror the "users" file.
   #
   #  See "Authorization Queries" in sql.conf
-# sql
+<% if node['freeradius']['enable_sql'] %>
+  sql
+<% end %>
 
   #
   #  If you are using /etc/smbpasswd, and are also doing
@@ -171,7 +173,6 @@ authorize {
   ldap
 <% end %>
 
-  #
   #  Enforce daily limits on time spent logged in.
 # daily
 
@@ -388,7 +389,9 @@ accounting {
   #  Log traffic to an SQL database.
   #
   #  See "Accounting queries" in sql.conf
-# sql
+<% if node['freeradius']['enable_sql'] %>
+  sql
+<% end %>
 
   #
   #  If you receive stop packets with zero session length,


### PR DESCRIPTION
Enable SQL support. SQL support was disabled inside `/etc/raddb/sites-available/default`. In addition, I added kitchen file, to simply test if cookbook converges without any errors.
